### PR TITLE
disable callback "hello"

### DIFF
--- a/src/kb_2315/backend/api/endpoints/line.py
+++ b/src/kb_2315/backend/api/endpoints/line.py
@@ -74,9 +74,7 @@ async def handle_callback(request: Request) -> Literal["OK"]:
                     send_to_id=return_id,
                 )
         else:
-            notify.line.send_message(
-                message="hello",
-                send_to_id=return_id,
-            )
+            # 普通に話しかけらた
+            pass
 
     return "OK"


### PR DESCRIPTION
API 節約のため，hello と返す機能の無効化